### PR TITLE
Added Command Line Options

### DIFF
--- a/readfram.py
+++ b/readfram.py
@@ -15,6 +15,8 @@ if __name__ == "__main__":
     parser.add_argument('image_path')
     parser.add_argument('-c', '--color', choices=range(1,9), default=2, type=int)
     parser.add_argument('--no-align-frames', action='store_true')
+    parser.add_argument('--debug', action='store_true')
+    parser.add_argument('--single-frame', default=-1, type=int)
     
     args = parser.parse_args()
     
@@ -34,7 +36,8 @@ if __name__ == "__main__":
     pixel_format = "RGBA"
 
     for frame_index, frame in enumerate(imagefile.frames):
-
+        if args.single_frame != -1 and args.single_frame != frame_index:
+            continue
     #print(imagefile.framecount)
     # frame = imagefile.frames[frame_index]
 

--- a/readfram.py
+++ b/readfram.py
@@ -2,19 +2,25 @@
 
 import sys
 import tgrlib
+import argparse
 from PIL import Image
 from pathlib import Path
 
 if __name__ == "__main__":
-    if len(sys.argv) < 2:
-        print("Provide a file to unpack")
-        exit()
-    image_path = sys.argv[1]
+    parser = argparse.ArgumentParser(
+                        prog='readfram',
+                        description='Reads a .TGR asset file and extracts each image frame to a .PNG',
+                        epilog='')
     
-    if len(sys.argv) > 2:
-        player_color = int(sys.argv[2])
-    else:
-        player_color = 2
+    parser.add_argument('image_path')
+    parser.add_argument('-c', '--color', choices=range(1,9), default=2, type=int)
+    parser.add_argument('--align-frames', action='store_true', default=True)
+    
+    args = parser.parse_args()
+    
+    image_path = args.image_path
+    
+    player_color = args.color
 
     imagefile = tgrlib.tgrFile(image_path, False)
 

--- a/readfram.py
+++ b/readfram.py
@@ -14,7 +14,7 @@ if __name__ == "__main__":
     
     parser.add_argument('image_path')
     parser.add_argument('-c', '--color', choices=range(1,9), default=2, type=int)
-    parser.add_argument('--align-frames', action='store_true', default=True)
+    parser.add_argument('--no-align-frames', action='store_true')
     
     args = parser.parse_args()
     
@@ -39,8 +39,11 @@ if __name__ == "__main__":
     # frame = imagefile.frames[frame_index]
 
         print(frame_index, frame.size)
-        image = Image.new(pixel_format, imagefile.size)
-        fram_img = Image.new(pixel_format, frame.size)
+        if args.no_align_frames:
+            image = Image.new(pixel_format, frame.size)
+        else:
+            image = Image.new(pixel_format, imagefile.size)
+            fram_img = Image.new(pixel_format, frame.size)
         imagedata = b""
         with open(image_path, "rb") as in_fh:
             for idx in range(len(frame.lines)):
@@ -57,9 +60,12 @@ if __name__ == "__main__":
         target_len = (frame.size[0] * frame.size[1]) * (3 if format == "RGB" else 4)
         if len(imagedata) < target_len:
             imagedata += bytes([0x00 for _ in range(target_len - len(imagedata))])
-        fram_img.frombytes(imagedata)
-        offset = imagefile.frameoffsets[frame_index][0]
-        image.paste(fram_img, offset)
+        if args.no_align_frames:
+            image.frombytes(imagedata)
+        else:
+            fram_img.frombytes(imagedata)
+            offset = imagefile.frameoffsets[frame_index][0]
+            image.paste(fram_img, offset)
         image.save(f"{image_name}/fram_{frame_index}.png")
 
         #image.save(f"{image_name}.png")

--- a/readfram.py
+++ b/readfram.py
@@ -8,15 +8,15 @@ from pathlib import Path
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
-                        prog='readfram',
+                        prog='readfram.py',
                         description='Reads a .TGR asset file and extracts each image frame to a .PNG',
                         epilog='')
     
     parser.add_argument('image_path')
-    parser.add_argument('-c', '--color', choices=range(1,9), default=2, type=int)
-    parser.add_argument('--no-align-frames', action='store_true')
-    parser.add_argument('--debug', action='store_true')
-    parser.add_argument('--single-frame', default=-1, type=int)
+    parser.add_argument('-c', '--color', choices=range(1,9), default=2, type=int, help='Use the specified player color for extracted sprites. Defaults to 2 (blue)')
+    parser.add_argument('-v', '--verbose', action='store_true', help='Enable debugging printouts')
+    parser.add_argument('--no-align-frames', action='store_true', help='Disable frame alignment within image size')
+    parser.add_argument('--single-frame', default=-1, type=int, help='Extract only the specified frame')
     
     args = parser.parse_args()
     


### PR DESCRIPTION
Switched to using argparse for command line options, and added a few options and help text
* -c / --color sets the player color to use on an extracted sprite
* -v / --verbose can be used to turn on any debugging messages
* --no-align-frames disables frame alignment within image size (useful for debugging since lines & columns in the output image will match those in the tgr binary data)
* --single-frame extracts only the specified frame number (also for debugging)