### PR TITLE
Writing PNG to TGR

### DIFF
--- a/readfram.py
+++ b/readfram.py
@@ -69,6 +69,6 @@ if __name__ == "__main__":
             fram_img.frombytes(imagedata)
             offset = imagefile.frameoffsets[frame_index][0]
             image.paste(fram_img, offset)
-        image.save(f"{image_name}/fram_{frame_index}.png")
+        image.save(f"{image_name}/fram_{frame_index:04d}.png")
 
         #image.save(f"{image_name}.png")

--- a/readfram.py
+++ b/readfram.py
@@ -24,7 +24,7 @@ if __name__ == "__main__":
     
     player_color = args.color
 
-    imagefile = tgrlib.tgrFile(image_path, False)
+    imagefile = tgrlib.tgrFile(image_path, 'TGR', False)
 
     imagefile.load()
 

--- a/tgrlib.py
+++ b/tgrlib.py
@@ -349,7 +349,7 @@ class tgrFile:
     def look_ahead(self, p: Pixel, line_index, pixel_ix, matching=True):
         collected = 0
         if matching:
-            while p == Pixel(*self.img_data[line_index*self.size[0] + pixel_ix + 1 + collected]):
+            while p == Pixel(*self.img_data[line_index*self.size[0] + pixel_ix + collected + 1]):
                 collected += 1
                 if collected == 30:
                     break
@@ -360,6 +360,7 @@ class tgrFile:
                 collected += 1
                 if collected == 31:
                     break
+            print(f'      Look_Ahead: collected {collected} individual pixels')
             return collected
         
     
@@ -374,7 +375,20 @@ class tgrFile:
             p = Pixel(*self.img_data[line_index*self.size[0] + pixel_ix])
             if verbose:
                 print(f'reading p:{p} at l:{line_index} c:{pixel_ix}')
-
+            
+            
+# =============================================================================
+#             (r,g,b,a) = Pixel(*self.img_data[line_index*self.size[0] + pixel_ix]).to_int()
+#             if verbose:
+#                 print(f'    r:{r} g:{g} b:{b} a:{a}')
+#                 
+#             body = (r << 11) + (g << 5) + b
+#             print(f'    packing body:{body:04X}')
+#             out_fh.write(struct.pack('<H', body))
+#             pixel_ix += 1
+# =============================================================================
+            
+            
             if p.alpha == 0:        # Encode transparent pixels
                 if verbose:
                     print(f'  chose flag 0b000')
@@ -436,10 +450,11 @@ class tgrFile:
                     out_fh.write(struct.pack('<B', header))
                     if verbose:
                         print(f'  packing header {header:02X}')
-                    for i in range(pixel_ix,pixel_ix+run_length):
-                        (r,g,b,a) = Pixel(*self.img_data[line_index*self.size[0] + pixel_ix + i]).to_int()
+                    for i in range(0,run_length):
+                        cur_pix = Pixel(*self.img_data[line_index*self.size[0] + pixel_ix + i])
+                        (r,g,b,a) = cur_pix.to_int()
                         if verbose:
-                            print(f'    r:{r} g:{g} b:{b} a:{a}')
+                            print(f'    p:{cur_pix} r:{r} g:{g} b:{b} a:{a}')
                         body = (r << 11) + (g << 5) + b
                         out_fh.write(struct.pack('<H', body))
                         if verbose:

--- a/tgrlib.py
+++ b/tgrlib.py
@@ -615,6 +615,7 @@ class tgrFile:
         
         animations = self.packAnimations()
         frame_sizes = self.packFrameSizes(animations)
+        print(frame_sizes[:16])
         
         out_text = (f'version:{type(version)}\n'+
                     f'frame_count:{type(frame_count)}\n'+
@@ -633,7 +634,7 @@ class tgrFile:
                     )
         print(out_text)
         
-        hedr_buf = struct.pack('I12HQI',
+        hedr_buf = struct.pack('I12HIII',
                                version,
                                frame_count,
                                self.bits_per_px,
@@ -647,9 +648,11 @@ class tgrFile:
                                bb[1],
                                bb[2],
                                bb[3],
-                               0xFFFF,
+                               0,
+                               0,
                                palette_offset)
         #print(f'frame_sizes:{frame_sizes}')
+        print(hedr_buf)
         hedr_buf += frame_sizes + animations
         chunk_length = len(hedr_buf)
         print(f'chunk_name:{chunk_name}:{type(chunk_name)}\nchunk_length:{chunk_length}:{type(chunk_length)}')

--- a/tgrlib.py
+++ b/tgrlib.py
@@ -191,7 +191,14 @@ class tgrFile:
             case 'TGR':
                 self.iff = ifflib.iff_file(self.filename)
             case 'PNG':
-                self.img = Image.open(self.filename)
+                self.imgs = []
+                if self.filename.is_file():
+                    self.imgs.append(Image.open(self.filename))
+                elif self.filename.is_dir():
+                    for f in Path(self.filename).glob('*.'+read_from):
+                        if f.is_file():
+                            print(f)
+                            self.imgs.append(Image.open(f))
             case _:
                 print(f"Error: invalid read type {self.read_from}")
                 

--- a/writetgr.py
+++ b/writetgr.py
@@ -1,9 +1,13 @@
 import tgrlib
+from pathlib import Path
 
-imagefile = tgrlib.tgrFile('./ADELLON_MAJERE_PORTRAIT/fram_0.png', 'PNG')
+imagefile = tgrlib.tgrFile(Path('./GRENADIER'), 'PNG')
 imagefile.load()
 #imagefile.encodeLine(line_index=0)
-data = imagefile.encodeFrame(frame_index=0)
+data = b''
+for frame_index in range(0,len(imagefile.img_data)):
+    data += imagefile.encodeFrame(frame_index)
+#data = imagefile.encodeFrame(frame_index=306)
 with open('./outfile.tgr','wb') as fh_out:
     fh_out.write(data)
 

--- a/writetgr.py
+++ b/writetgr.py
@@ -1,0 +1,38 @@
+import tgrlib
+
+imagefile = tgrlib.tgrFile('./ADELLON_MAJERE_PORTRAIT/fram_0.png', 'PNG')
+imagefile.load()
+#imagefile.encodeLine(line_index=0)
+imagefile.encodeLine(line_index=1)
+
+
+
+# =============================================================================
+# flag = 0b010 << 5
+# run_length = unique + 1
+# header = flag + (run_length & 0b11111)
+# out_fh.write(struct.pack('<B', header))
+# if verbose:
+#     print(f'  packing header {header:02X}')
+# for i in range(pixel_ix,pixel_ix+run_length):
+#     (r,g,b,a) = Pixel(*self.img_data[line_index*self.size[0] + pixel_ix + i]).to_int()
+#     if verbose:
+#         print(f'    r:{r} g:{g} b:{b} a:{a}')
+#     body = (r << 11) + (g << 5) + b
+#     out_fh.write(struct.pack('<H', body))
+#     if verbose:
+#         print(f'    packing body:{body:04X}')
+# pixel_ix += run_length
+# if verbose:
+#     print(f'  advanced to c:{pixel_ix}')
+#     
+# r = 31
+# g = 0
+# b = 31
+# body = (r << 11) + (g << 5) + b
+# print(struct.pack('<H', body))
+# p = Pixel.from_int(body)
+# print(p)
+# print(p.to_int())
+# =============================================================================
+

--- a/writetgr.py
+++ b/writetgr.py
@@ -6,6 +6,7 @@ imagefile.load()
 #imagefile.encodeLine(line_index=0)
 data = b''
 for frame_index in range(0,len(imagefile.img_data)):
+    imagefile.frameoffsets.append(len(data))
     data += imagefile.encodeFrame(frame_index)
 data = imagefile.encodeHeader(data)
 data = imagefile.encodeForm(data)

--- a/writetgr.py
+++ b/writetgr.py
@@ -3,7 +3,9 @@ import tgrlib
 imagefile = tgrlib.tgrFile('./ADELLON_MAJERE_PORTRAIT/fram_0.png', 'PNG')
 imagefile.load()
 #imagefile.encodeLine(line_index=0)
-imagefile.encodeLine(line_index=1)
+data = imagefile.encodeFrame(frame_index=0)
+with open('./outfile.tgr','wb') as fh_out:
+    fh_out.write(data)
 
 
 

--- a/writetgr.py
+++ b/writetgr.py
@@ -7,7 +7,8 @@ imagefile.load()
 data = b''
 for frame_index in range(0,len(imagefile.img_data)):
     data += imagefile.encodeFrame(frame_index)
-#data = imagefile.encodeFrame(frame_index=306)
+data = imagefile.encodeHeader(data)
+data = imagefile.encodeForm(data)
 with open('./outfile.tgr','wb') as fh_out:
     fh_out.write(data)
 


### PR DESCRIPTION
Extends the tgrFile class to be able to process an image or directory of images into FRAM chunks, then pack to TGR.
Currently, the animation data (packed directly after the frame sizes in the header), is a hard-coded copy of the animation data from grenadier.ini. This should be replaced with a config file specifying the location, frame count, and frame speed of the sprite's animations, as well as the type of game asset being packed (portrait, feature, unit, etc)
Currently, the loose files to pack are specified in writetgr.py. This should be updated with a CLI and documentation to streamline the process