### PR TITLE
Pyinstaller Compatibility

### DIFF
--- a/tgrlib.py
+++ b/tgrlib.py
@@ -84,7 +84,7 @@ transparency = Pixel(0x00, 0xff, 0xff, 0x00)
 
 def load_player_colors(filename: str = "COLORS.INI"):
     c_file = ConfigParser()
-    c_file.read(filename)
+    c_file.read(Path(__file__).resolve().with_name(filename))
     player_cols = {}
     c_name_re = re.compile(r"color_(\d{1,2})_shade_(\d{1,2})")
     c_value_re = re.compile(r"\W*(\d{1,3}),(\d{1,3}),(\d{1,3})")

--- a/tgrtool.spec
+++ b/tgrtool.spec
@@ -1,0 +1,44 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+
+block_cipher = None
+
+
+a = Analysis(
+    ['tgrtool.py'],
+    pathex=[],
+    binaries=[],
+    datas=[('.\\COLORS.INI', '.')],
+    hiddenimports=[],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=block_cipher,
+    noarchive=False,
+)
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    [],
+    name='tgrtool',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    runtime_tmpdir=None,
+    console=True,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)


### PR DESCRIPTION
Created .spec file and modified load_player_color to work while bundled by pyinstaller.
To compile an executable, install pyinstaller and run ```pyinstaller tgrtool.spec``` in the same folder as tgrtool.py