### PR TITLE
Properly handle padding FRAM chunks

### DIFF
--- a/tgr.bt
+++ b/tgr.bt
@@ -34,15 +34,15 @@ typedef struct {
 // Represents an 'immediate color' pixel (16 bits representing color)
 typedef struct {
     LittleEndian();
-    uint16 blue : 5;
-    uint16 green : 6;
-    uint16 red : 5;
-} IMM_PIXEL <optimize=false,bgcolor=PixelColor,comment=ColorComment>;
+    ubyte blue : 5;
+    ubyte green : 6;
+    ubyte red : 5;
+} IMM_PIXEL <optimize=false,bgcolor=PixelColor,comment=ImmColorComment>;
 
 // Represents an 'indexed color' pixel (8 bits representing palette index)   
 typedef struct {
     ubyte index;
-} IND_PIXEL;
+} IND_PIXEL <optimize=false, bgcolor=IndPixelColor, comment=IndColorComment>;
 
 // Represents two 'player color' pixels, packed into one byte. 
 // Perform (pixelN << 1) | 1 to calculate the actual index value
@@ -61,7 +61,7 @@ int64 PixelColor( IMM_PIXEL &p ) {
     //return 0xFFFFFF;
 }
 
-string ColorComment ( IMM_PIXEL &p ) {
+string ImmColorComment ( IMM_PIXEL &p ) {
     local double r8 = (double)p.red / 31.0 * 255.0;
     if ( r8 > (Floor(r8) + 0.5) ) {
         r8 = Ceil(r8);
@@ -83,16 +83,46 @@ string ColorComment ( IMM_PIXEL &p ) {
     return Str("r:%d g:%d b:%d", r8, g8, b8);
 }
 
+int64 IndPixelColor( IND_PIXEL &p ) {
+    local uint64 r8 = (double)palt.pixels[p.index].red / 31.0 * 255.0;
+    local uint64 g8 = (double)palt.pixels[p.index].green / 63.0 * 255.0;
+    local uint64 b8 = (double)palt.pixels[p.index].blue / 31.0 * 255.0;
+    return (b8 << 16 | g8 << 8 | r8);
+    //return 0xFFFFFF;
+}
+
+string IndColorComment ( IND_PIXEL &p ) {
+    local double r8 = (double)palt.pixels[p.index].red / 31.0 * 255.0;
+    if ( r8 > (Floor(r8) + 0.5) ) {
+        r8 = Ceil(r8);
+    } else {
+        r8 = Floor(r8);
+    }
+    local double g8 = (double)palt.pixels[p.index].green / 63.0 * 255.0;
+    if ( g8 > (Floor(g8) + 0.5) ) {
+        g8 = Ceil(g8);
+    } else {
+        g8 = Floor(g8);
+    }
+    local double b8 = (double)palt.pixels[p.index].blue / 31.0 * 255.0;
+    if ( b8 > (Floor(b8) + 0.5) ) {
+        b8 = Ceil(b8);
+    } else {
+        b8 = Floor(b8);
+    }
+    return Str("r:%d g:%d b:%d", r8, g8, b8);
+}
+
 typedef struct {
     BigEndian();
     //local uchar run_header = ReadUByte() >> 5;
     switch(ReadUByte() >> 5) {
         case 0b000:     // Transparent spacing pixels
-            ubyte run_type : 3;
+            ubyte run_type : 3 <comment="Transparent Padding">;
             ubyte ct_transparent_pixels : 5;
             break;
         case 0b001:     // Run length encoded run of pixels
-            ubyte run_type : 3;
+            ubyte run_type : 3 <comment="RLE single-color run">;
             ubyte run_length : 5;
             if (hedr.bit_depth == 8) {
                 IND_PIXEL ind_pixel;
@@ -101,7 +131,7 @@ typedef struct {
             }
             break;
         case 0b010:     // Unencoded run of pixels
-            ubyte run_type : 3;
+            ubyte run_type : 3 <comment="RLE multi-color run">;
             ubyte run_length : 5;
             if (hedr.bit_depth == 8) {
                 IND_PIXEL ind_pixels[run_length];
@@ -110,7 +140,7 @@ typedef struct {
             }
             break;
         case 0b011:     // Run length encoded run of translucent/glowing colored pixels
-            ubyte run_type : 3;
+            ubyte run_type : 3 <comment="RLE single-color run with alpha">;
             ubyte run_length : 5;
             ubyte alpha;
             if (hedr.bit_depth == 8) {
@@ -120,7 +150,7 @@ typedef struct {
             }
             break;
         case 0b100:     // Sets the brightness of a single translucent pixel
-            ubyte run_type : 3;
+            ubyte run_type : 3 <comment="Single pixel with alpha">;
             ubyte alpha : 5;
             if (hedr.bit_depth == 8) {
                 IND_PIXEL ind_pixel;
@@ -129,21 +159,21 @@ typedef struct {
             }
             break;
         case 0b101:     // Shadow pixels in sprites
-            ubyte run_type : 3;
+            ubyte run_type : 3 <comment="Shadow pixels">;
             ubyte ct_shadow_pixels : 5;
             break;
         case 0b110:     // One Player Color pixel
-            ubyte run_type : 3 <bgcolor=cRed>;
+            ubyte run_type : 3 <comment="Single player-colored pixel", bgcolor=cRed>;
             ubyte player_color : 5;
             break;
         case 0b111:     // Run Length encoded run of player color pixels
             local ubyte flag = ReadByte();
             if ((flag & 0b00011111) > 0b11011) {
-                uint16 run_type : 3;
-                uint16 fixed_bits : 3;
-                uint16 ix_l : 2;
-                uint16 ix_h : 3 <comment="Use (ix_h<<2)|ix_l for correct index">;
-                uint16 alpha : 5;
+                ubyte run_type : 3 <comment="RLE player-pixel run">;
+                ubyte fixed_bits : 3;
+                ubyte ix_l : 2;
+                ubyte ix_h : 3 <comment="Use (ix_h<<2)|ix_l for correct index">;
+                ubyte alpha : 5;
             } else {
                 ubyte run_type : 3;
                 ubyte run_length : 5;                

--- a/tgrlib.py
+++ b/tgrlib.py
@@ -217,6 +217,7 @@ class tgrFile:
         self.framesizes = []
         self.frameoffsets = []
         self.frames = []
+        self.padding_frames = []
 
     def load(self, config_path: str|None=None, no_crop=False):
         match self.read_from:
@@ -463,6 +464,13 @@ class tgrFile:
         config.set('BoundingBox', 'XMax', str(self.bounding_box[2]))
         config.set('BoundingBox', 'YMax', str(self.bounding_box[3]))
         
+        config.add_section('PaddingFrames')
+        config.set('PaddingFrames', ('; Building sprites reserve frames 0 through 2 for specific purposes:\n'+
+                                     '; Frame 0 is the base sprite. This is always displayed\n'+
+                                     '; Frame 1 is the wall overlay sprite\n'
+                                     '; Frame 2 is always left as a zero-length padding frame'))
+        config.set('PaddingFrames', 'FrameList', ','.join(map(str, self.padding_frames)))
+        
         config.add_section('Animations')
         config.set('Animations', ('; Sprites can have up to six animations, each consisting of a Start Frame, Frame Count, and Animation Count\n'+
                                   '; Start Frame is the first frame of the West-facing version of the animation. Subsequent versions are in counterclockwise order\n'+
@@ -474,7 +482,6 @@ class tgrFile:
                                   '; Animation3 is Idle for units\n'+
                                   '; Animation4 is Attack1 for units\n'+
                                   '; Animation5 is Rot for units and projectiles'))
-        
         for i in range(self.anim_count):
             config.add_section(f'Animation{i}')
             config.set(f'Animation{i}', 'StartFrame', str(self.animations[i][0]))

--- a/tgrlib.py
+++ b/tgrlib.py
@@ -161,13 +161,13 @@ class Frame:
     def __init__(self, size, in_fh: io.BufferedReader):
         self.size = size
         self.lines = []
-        while True:
+        while len(self.lines) < self.size[1]:
             newline = Line(in_fh, False)
             #if newline.data_length == 0:
             #    continue
             self.lines.append(newline)
-            if len(self.lines) >= self.size[1]:
-                break
+            #if len(self.lines) >= self.size[1]:
+            #    break
             in_fh.seek(newline.offset + newline.data_length)
 
 class tgrFile:
@@ -272,12 +272,12 @@ class tgrFile:
                 (ulx, uly, lrx, lry, offset) = struct.unpack("HHHHI", in_fh.read(12))
                 # Skip empty frames (offset will be zero)
                 if offset == 0:
+                    self.framesizes.append((0, 0, 0))
+                    self.frameoffsets.append(((0, 0), (0, 0)))
                     print(f'Skipping Frame {_} because it is empty. Please adjust animations in sprite.ini accordingly')
-                    continue
-                #in_fh.seek(4, 1)
-                #self.framesizes.append(struct.unpack("HH", in_fh.read(4)))
-                self.framesizes.append((1+lrx-ulx, 1+lry-uly, offset))
-                self.frameoffsets.append(((ulx, uly), (lrx, lry)))
+                else:
+                    self.framesizes.append((1+lrx-ulx, 1+lry-uly, offset))
+                    self.frameoffsets.append(((ulx, uly), (lrx, lry)))
             
             self.anim_count = struct.unpack('H',in_fh.read(2))[0]
             self.animations = []

--- a/tgrtool.py
+++ b/tgrtool.py
@@ -2,6 +2,7 @@
 
 import argparse
 import tgrlib
+import struct
 from pathlib import Path
 from PIL import Image
 
@@ -97,8 +98,12 @@ def pack(args: argparse.Namespace):
     
     data = b''
     for frame_index in range(0,len(imagefile.img_data)):
-        imagefile.frameoffsets.append(len(data))
-        data += imagefile.encodeFrame(frame_index, color=args.color)
+        if frame_index in imagefile.padding_frames:
+            imagefile.frameoffsets.append(0)
+            data += struct.pack('4sI', b'FRAM', 0)
+        else:
+            imagefile.frameoffsets.append(len(data))
+            data += imagefile.encodeFrame(frame_index, color=args.color)
     data = imagefile.encodeHeader(data)
     data = imagefile.encodeForm(data)
     print("writing to: ", outfile)

--- a/tgrtool.py
+++ b/tgrtool.py
@@ -24,6 +24,14 @@ def unpack(args: argparse.Namespace):
     frame_index = 0
     pixel_format = "RGBA"
     for frame_index, frame in enumerate(imagefile.frames):
+        
+        # Check for padding (blank) frames
+        if frame.size == (0, 0,):
+            print(f'padding frame {frame_index}')
+            image = Image.new('RGBA',(1,1),(0,0,0,0))
+            image.save(f"{image_name}/fram_{frame_index:04d}.png")
+            continue            
+        
         if args.single_frame != -1 and args.single_frame != frame_index:
             continue
     #print(imagefile.framecount)

--- a/tgrtool.py
+++ b/tgrtool.py
@@ -28,6 +28,7 @@ def unpack(args: argparse.Namespace):
         # Check for padding (blank) frames
         if frame.size == (0, 0,):
             print(f'padding frame {frame_index}')
+            imagefile.padding_frames.append(frame_index)
             image = Image.new('RGBA',(1,1),(0,0,0,0))
             image.save(f"{image_name}/fram_{frame_index:04d}.png")
             continue            


### PR DESCRIPTION
FRAMs 0-2 of building sprites each store a specific image (base, wall, etc), and are left in as null padding frames if not used. This fix properly handles the packing and unpacking of these sprites by storing padding frames in the config, and appropriately repacking the header data to match example files.