### PR TITLE
Fixed object reference error in extractLine & off-by-1 palette read error

### DIFF
--- a/tgr.bt
+++ b/tgr.bt
@@ -84,27 +84,27 @@ string ImmColorComment ( IMM_PIXEL &p ) {
 }
 
 int64 IndPixelColor( IND_PIXEL &p ) {
-    local uint64 r8 = (double)palt.pixels[p.index].red / 31.0 * 255.0;
-    local uint64 g8 = (double)palt.pixels[p.index].green / 63.0 * 255.0;
-    local uint64 b8 = (double)palt.pixels[p.index].blue / 31.0 * 255.0;
+    local uint64 r8 = (double)PALT.pixels[p.index].red / 31.0 * 255.0;
+    local uint64 g8 = (double)PALT.pixels[p.index].green / 63.0 * 255.0;
+    local uint64 b8 = (double)PALT.pixels[p.index].blue / 31.0 * 255.0;
     return (b8 << 16 | g8 << 8 | r8);
     //return 0xFFFFFF;
 }
 
 string IndColorComment ( IND_PIXEL &p ) {
-    local double r8 = (double)palt.pixels[p.index].red / 31.0 * 255.0;
+    local double r8 = (double)PALT.pixels[p.index].red / 31.0 * 255.0;
     if ( r8 > (Floor(r8) + 0.5) ) {
         r8 = Ceil(r8);
     } else {
         r8 = Floor(r8);
     }
-    local double g8 = (double)palt.pixels[p.index].green / 63.0 * 255.0;
+    local double g8 = (double)PALT.pixels[p.index].green / 63.0 * 255.0;
     if ( g8 > (Floor(g8) + 0.5) ) {
         g8 = Ceil(g8);
     } else {
         g8 = Floor(g8);
     }
-    local double b8 = (double)palt.pixels[p.index].blue / 31.0 * 255.0;
+    local double b8 = (double)PALT.pixels[p.index].blue / 31.0 * 255.0;
     if ( b8 > (Floor(b8) + 0.5) ) {
         b8 = Ceil(b8);
     } else {
@@ -124,7 +124,7 @@ typedef struct {
         case 0b001:     // Run length encoded run of pixels
             ubyte run_type : 3 <comment="RLE single-color run">;
             ubyte run_length : 5;
-            if (hedr.bit_depth == 8) {
+            if (HEDR.bit_depth == 8) {
                 IND_PIXEL ind_pixel;
             } else {
                 IMM_PIXEL pixel;
@@ -133,7 +133,7 @@ typedef struct {
         case 0b010:     // Unencoded run of pixels
             ubyte run_type : 3 <comment="RLE multi-color run">;
             ubyte run_length : 5;
-            if (hedr.bit_depth == 8) {
+            if (HEDR.bit_depth == 8) {
                 IND_PIXEL ind_pixels[run_length];
             } else {
                 IMM_PIXEL pixels[run_length];
@@ -143,7 +143,7 @@ typedef struct {
             ubyte run_type : 3 <comment="RLE single-color run with alpha">;
             ubyte run_length : 5;
             ubyte alpha;
-            if (hedr.bit_depth == 8) {
+            if (HEDR.bit_depth == 8) {
                 IND_PIXEL ind_pixel;
             } else {
                 IMM_PIXEL pixel;
@@ -152,7 +152,7 @@ typedef struct {
         case 0b100:     // Sets the brightness of a single translucent pixel
             ubyte run_type : 3 <comment="Single pixel with alpha">;
             ubyte alpha : 5;
-            if (hedr.bit_depth == 8) {
+            if (HEDR.bit_depth == 8) {
                 IND_PIXEL ind_pixel;
             } else {
                 IMM_PIXEL pixel;
@@ -236,7 +236,7 @@ typedef struct {
     uint32 chunk_length; //distance from end of chunk_length to next FRAM
     LittleEndian();
     // If TGR is a terrain file
-    if (hedr.file_type == 2) {
+    if (HEDR.file_type == 2) {
         struct TERRAIN {
             IMM_PIXEL pixel[1024];
             char footer[chunk_length - 2048];
@@ -253,7 +253,7 @@ typedef struct {
             }
         }
     }
-} FRAM <optimize=false>;
+} FRAM_CHUNK <optimize=false>;
 
 typedef struct {
     char chunk_name[4];
@@ -261,20 +261,19 @@ typedef struct {
     uint32 chunk_length;
     LittleEndian();
     uint16 palette_size;
-    ubyte unknown[2];  // Palette size can only be 256, so these bytes are for something else
     IMM_PIXEL pixels[palette_size] <optimize=false>;
-} PALT;
+} PALT_CHUNK;
 
 
-struct FORM {
+typedef struct {
     char chunk_name[4];  // Always FORM
     BigEndian();
     int32 length;  //length in bytes from start of HEDR to end of file
     LittleEndian();
     char file_type[4];  // Always TGAR
-} form;
+} FORM_CHUNK;
 
-struct HEDR {
+typedef struct {
     char chunk_name[4];
     BigEndian();
     uint32 chunk_length;
@@ -312,23 +311,32 @@ struct HEDR {
     
     uint16 anim_count;
     ANIMATION anim[anim_count];
-    
-    //if (hedr.anim_count % 2 == 0) {
-    //    ubyte padding[2];
-    //}
-    local uint32 curr_pos = FTell();
-    if (curr_pos < start_pos + chunk_length) {
-        ubyte padding[start_pos + chunk_length - curr_pos];
-    }
-} hedr;
+} HEDR_CHUNK;
 
-/*if (hedr.anim_count % 2 == 0) {
-        ubyte padding[2];
-    }
-*/
 
-if (hedr.bit_depth == 8) {
-    PALT palt;
+typedef struct {
+    char chunk_name[4];
+    BigEndian();
+    uint32 chunk_length <fgcolor=0x3C8E38>;
+    LittleEndian();
+    char data[chunk_length];
+} PLACEHOLDER_CHUNK;
+
+local uchar chunk_name[4];
+FSeek(0);
+local int start_pos = 0;
+while (!FEof()) {
+    start_pos = FTell();
+    ReadBytes(chunk_name, start_pos, 4);
+    switch(chunk_name) {
+        case "FORM": FORM_CHUNK FORM; FSeek(start_pos + 12); break;
+        case "HEDR": HEDR_CHUNK HEDR; FSeek(start_pos + HEDR.chunk_length + 8); break;
+        case "PALT": PALT_CHUNK PALT; FSeek(start_pos + PALT.chunk_length + 8); break;
+        case "FRAM": FRAM_CHUNK FRAM; FSeek(start_pos + FRAM.chunk_length + 8); break;
+        
+        default:
+            PLACEHOLDER_CHUNK chunk;
+            //FSeek(FTell()+chunk.chunk_length);
+            break;
+    }
 }
-    
-FRAM frames[hedr.frame_count];

--- a/tgrlib.py
+++ b/tgrlib.py
@@ -281,7 +281,7 @@ class tgrFile:
                 if offset == 0:
                     self.framesizes.append((0, 0, 0))
                     self.frameoffsets.append(((0, 0), (0, 0)))
-                    print(f'Skipping Frame {_} because it is empty. Please adjust animations in sprite.ini accordingly')
+                    print(f'Frame {_} is a padding frame. Leave frame as-is to avoid packing errors')
                 else:
                     self.framesizes.append((1+lrx-ulx, 1+lry-uly, offset))
                     self.frameoffsets.append(((ulx, uly), (lrx, lry)))

--- a/tgrlib.py
+++ b/tgrlib.py
@@ -296,7 +296,7 @@ class tgrFile:
         self.palette = []
         with open(self.filename, "rb") as in_fh:
             in_fh.seek(palt.data_offset)
-            (count,) = struct.unpack("<Hxx", in_fh.read(4))
+            (count,) = struct.unpack("<H", in_fh.read(2))
             print(f'Colors in Palette: {count}')
             for _ in range(count):
                 raw_pixel = in_fh.read(2)
@@ -304,8 +304,7 @@ class tgrFile:
                     raise ValueError("Not enough image data")
                 (pixel,) = struct.unpack("H", raw_pixel)
                 self.palette.append(Pixel.from_int(pixel))
-        #print(len(self.palette))
-    
+
     def get_frames(self):
         with open(self.filename, "rb") as in_fh:
             for child in self.framesizes:
@@ -316,7 +315,7 @@ class tgrFile:
     def get_next_pixel(self, in_fh: io.BufferedReader):
         if self.indexed_colour:
             (pixel_ix,) = struct.unpack("B", in_fh.read(1))
-            return self.palette[pixel_ix-1]
+            return self.palette[pixel_ix]
         else:
             (raw_pixel,) = struct.unpack("H", in_fh.read(2))
             return Pixel.from_int(raw_pixel)


### PR DESCRIPTION
Whenever another pixel was read and appended to outbuf, append() was passing a reference to the Pixel object in memory, rather than copying the value of the Pixel. This was causing subsequent reads to modify previously read pixel data.
I added Pixel.copy() to return a new, identical object, and swapped this method in to all the .append() calls to fix this.
PALT chunks were being read 2 bytes later than they should have been. Fixed in both tgrlib.py and tgr.bt